### PR TITLE
fix: enable cross origin for case API

### DIFF
--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/Utils/configs/SecurityConfig.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/Utils/configs/SecurityConfig.java
@@ -6,10 +6,9 @@ import advogados_popular.api_advogados_popular.sevices.UserDetailsServiceImpl;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -17,7 +16,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
@@ -43,10 +44,12 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf().disable()
+                .csrf(csrf -> csrf.disable())
+                .cors(Customizer.withDefaults())
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/usuarios/**", "/login", "/swagger-ui/**", "/v3/api-docs/**",
-                                "/advogados","/causas").permitAll()
+                                "/advogados", "/causas").permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -58,5 +61,17 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(java.util.List.of("http://localhost:9002"));
+        configuration.setAllowedMethods(java.util.List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(java.util.List.of("*"));
+        configuration.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/front-advogados-backup-master/src/app/cases/[id]/page.tsx
+++ b/front-advogados-backup-master/src/app/cases/[id]/page.tsx
@@ -32,9 +32,11 @@ export default function CaseDetailsPage() {
       if (!token) return;
       try {
         const response = await fetch(`${API_BASE_URL}/causas/${caseId}`, {
+          method: 'GET',
           headers: {
             "Authorization": `Bearer ${token}`,
           },
+          mode: 'cors',
         });
         if (!response.ok) {
           const errorData = await response.json();

--- a/front-advogados-backup-master/src/components/CaseList.tsx
+++ b/front-advogados-backup-master/src/components/CaseList.tsx
@@ -51,9 +51,11 @@ const CaseList: React.FC<CaseListProps> = ({ apiEndpoint = '/causas' }) => {
       setError(null);
       try {
         const response = await fetch(`${API_BASE_URL}${apiEndpoint}`, {
+          method: 'GET',
           headers: {
             "Authorization": `Bearer ${token}`,
           },
+          mode: 'cors',
         });
         if (!response.ok) {
           const errorData = await response.json();


### PR DESCRIPTION
## Summary
- allow CORS from web client and permit preflight requests
- request case details and list with explicit CORS mode

## Testing
- `cd api-advogados-backup-master && ./mvnw -q test` *(fails: Non-resolvable parent POM, network is unreachable)*
- `cd front-advogados-backup-master && npm test` *(fails: Missing script: "test")*
- `cd front-advogados-backup-master && npm run typecheck` *(fails: Property 'pathname' does not exist on type 'AppRouterInstance')*

------
https://chatgpt.com/codex/tasks/task_e_689b1389b59c8329bbf5ed88e866955c