### PR TITLE
fix: submit bid with correct endpoint

### DIFF
--- a/front-advogados-backup-master/src/components/BidModal.tsx
+++ b/front-advogados-backup-master/src/components/BidModal.tsx
@@ -33,13 +33,13 @@ export default function BidModal({ caseId, open, onOpenChange }: BidModalProps) 
       return;
     }
     try {
-      const response = await fetch(`${API_BASE_URL}/causas/${caseId}/lances`, {
+      const response = await fetch(`${API_BASE_URL}/lances`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${token}`,
         },
-        body: JSON.stringify({ valor: parseFloat(value), comentario: comment })
+        body: JSON.stringify({ causaId: caseId, valor: parseFloat(value) })
       });
       if (!response.ok) {
         throw new Error('Falha ao enviar o lance');


### PR DESCRIPTION
## Summary
- fix bid submission to call `/lances` endpoint with cause id

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck` *(fails: Property 'pathname' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689c720177088329807da0830da170b9