### PR TITLE
feat: include bid comments and adjust cors

### DIFF
--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/DTOs/Lance/LanceRequestDTO.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/DTOs/Lance/LanceRequestDTO.java
@@ -2,6 +2,6 @@ package advogados_popular.api_advogados_popular.DTOs.Lance;
 
 import java.math.BigDecimal;
 
-public record LanceRequestDTO(Long causaId, BigDecimal valor) {
+public record LanceRequestDTO(Long causaId, BigDecimal valor, String comentario) {
 }
 

--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/Utils/configs/SecurityConfig.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/Utils/configs/SecurityConfig.java
@@ -66,7 +66,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(java.util.List.of("http://localhost:9002"));
+        configuration.setAllowedOrigins(java.util.List.of("http://localhost:9002", "http://localhost:3000"));
         configuration.setAllowedMethods(java.util.List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(java.util.List.of("*"));
         configuration.setAllowCredentials(true);

--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/sevices/LanceService.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/sevices/LanceService.java
@@ -8,6 +8,9 @@ import advogados_popular.api_advogados_popular.Repositorys.*;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Service
 public class LanceService {
 
@@ -50,6 +53,14 @@ public class LanceService {
         Chat chat = new Chat();
         chat.setLance(lance);
         chat.setPropostaAceita(false);
+        if (dto.comentario() != null && !dto.comentario().isBlank()) {
+            Mensagem mensagem = new Mensagem();
+            mensagem.setChat(chat);
+            mensagem.setConteudo(dto.comentario());
+            mensagem.setEnviadaEm(LocalDateTime.now());
+            mensagem.setRemetente("ADVOGADO");
+            chat.setMensagens(List.of(mensagem));
+        }
         lance.setChat(chat);
 
         Lance salvo = lanceRepository.save(lance);


### PR DESCRIPTION
## Summary
- allow extra `comentario` field when submitting bids and persist as initial chat message
- permit front-end origins on ports 9002 and 3000

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689c782eb5548329ad970d30ab7b7dc5