### PR TITLE
Handle missing lawyer during bid creation

### DIFF
--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/Repositorys/AdvogadoRepository.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/Repositorys/AdvogadoRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 
 public interface AdvogadoRepository extends JpaRepository<Advogado, Long> {
     Optional<Advogado> findByAccount(Account account);
+
+    Optional<Advogado> findByAccountEmail(String email);
 }

--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/sevices/LanceService.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/sevices/LanceService.java
@@ -5,8 +5,10 @@ import advogados_popular.api_advogados_popular.DTOs.Lance.LanceResponseDTO;
 import advogados_popular.api_advogados_popular.DTOs.utils.Role;
 import advogados_popular.api_advogados_popular.Entitys.*;
 import advogados_popular.api_advogados_popular.Repositorys.*;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -33,17 +35,17 @@ public class LanceService {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
 
         Account account = accountRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("Conta não encontrada"));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Conta não encontrada"));
 
         if (account.getRole() != Role.ADVOGADO) {
-            throw new RuntimeException("Apenas advogados podem enviar lances.");
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Apenas advogados podem enviar lances.");
         }
 
-        Advogado advogado = advogadoRepository.findByAccount(account)
-                .orElseThrow(() -> new RuntimeException("Advogado não encontrado"));
+        Advogado advogado = advogadoRepository.findByAccountEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Advogado não encontrado"));
 
         Causa causa = causaRepository.findById(dto.causaId())
-                .orElseThrow(() -> new RuntimeException("Causa não encontrada"));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Causa não encontrada"));
 
         Lance lance = new Lance();
         lance.setValor(dto.valor());


### PR DESCRIPTION
## Summary
- Add repository method to locate lawyer by account email
- Improve bid creation flow to return proper status codes when the authenticated lawyer or account is missing

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c90c6e1e08329a00fefd02923701d