### PR TITLE
Fix lawyer lookup and profile naming

### DIFF
--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/Repositorys/AdvogadoRepository.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/Repositorys/AdvogadoRepository.java
@@ -8,6 +8,4 @@ import java.util.Optional;
 
 public interface AdvogadoRepository extends JpaRepository<Advogado, Long> {
     Optional<Advogado> findByAccount(Account account);
-
-    Optional<Advogado> findByAccountEmail(String email);
 }

--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/sevices/LanceService.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/sevices/LanceService.java
@@ -41,7 +41,7 @@ public class LanceService {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Apenas advogados podem enviar lances.");
         }
 
-        Advogado advogado = advogadoRepository.findByAccountEmail(email)
+        Advogado advogado = advogadoRepository.findByAccount(account)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Advogado não encontrado"));
 
         Causa causa = causaRepository.findById(dto.causaId())

--- a/front-advogados-backup-master/src/components/LoginFormComponent.tsx
+++ b/front-advogados-backup-master/src/components/LoginFormComponent.tsx
@@ -75,10 +75,11 @@ export function LoginFormComponent() {
       }
 
       const userData = {
-        name: result.nome || result.name || (result.user ? result.user.name : "Usuário"), 
+        name: result.nome || result.name ||
+              (result.user ? result.user.name : (userRole === 'ADVOGADO' ? 'Advogado' : 'Usuário')),
         email: result.email || (result.user ? result.user.email : data.email),
         role: userRole,
-        oab: result.oab || (result.user ? result.user.oab : undefined), 
+        oab: result.oab || (result.user ? result.user.oab : undefined),
       };
 
       // If user is USUARIO, attempt to create a default case


### PR DESCRIPTION
## Summary
- ensure lawyer retrieval uses account instead of email
- remove unused repository method
- show role-based default name after login

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint setup)*
- `npm run typecheck` *(fails: Property 'pathname' does not exist on type 'AppRouterInstance')*

------
https://chatgpt.com/codex/tasks/task_e_689ca1b24f208329899ed6ea552d52c8