### PR TITLE
Fix chat messages relation to bids

### DIFF
--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/Entitys/Causa.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/Entitys/Causa.java
@@ -32,6 +32,7 @@ public class Causa {
     @JoinColumn(name = "advogado_id")
     private Advogado advogadoAtribuido;
 
+    @Enumerated(EnumType.STRING)
     private statusCausa status;
 
     @OneToMany(mappedBy = "causa")

--- a/api-advogados-backup-master/src/main/resources/db/migration/V1__create_tables.sql
+++ b/api-advogados-backup-master/src/main/resources/db/migration/V1__create_tables.sql
@@ -37,16 +37,22 @@ CREATE TABLE lances (
                         advogado_id BIGINT NOT NULL,
                         causa_id BIGINT NOT NULL,
                         valor DECIMAL(10,2) NOT NULL,
-                        status ENUM('PENDENTE', 'ACEITO', 'NEGOCIANDO') NOT NULL,
                         FOREIGN KEY (advogado_id) REFERENCES advogados(id) ON DELETE CASCADE,
                         FOREIGN KEY (causa_id) REFERENCES causas(id) ON DELETE CASCADE
 );
 
+CREATE TABLE chat (
+                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                        lance_id BIGINT NOT NULL,
+                        proposta_aceita BOOLEAN NOT NULL DEFAULT FALSE,
+                        FOREIGN KEY (lance_id) REFERENCES lances(id) ON DELETE CASCADE
+);
+
 CREATE TABLE mensagens (
                            id BIGINT AUTO_INCREMENT PRIMARY KEY,
-                           lance_id BIGINT NOT NULL,
+                           chat_id BIGINT NOT NULL,
+                           conteudo TEXT NOT NULL,
+                           enviada_em TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                            remetente ENUM('USUARIO', 'ADVOGADO') NOT NULL,
-                           mensagem TEXT NOT NULL,
-                           data_envio TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                           FOREIGN KEY (lance_id) REFERENCES lances(id) ON DELETE CASCADE
+                           FOREIGN KEY (chat_id) REFERENCES chat(id) ON DELETE CASCADE
 );


### PR DESCRIPTION
## Summary
- add missing `chat` table and rework `mensagens` table to reference `chat_id`
- align `Causa` status mapping with enum string

## Testing
- `mvn -q test` *(fails: Network is unreachable)*
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ca644a3ec83299ca04b3c60275dd4