### PR TITLE
Fix Flyway migration mismatch with new schema update

### DIFF
--- a/api-advogados-backup-master/src/main/resources/db/migration/V1__create_tables.sql
+++ b/api-advogados-backup-master/src/main/resources/db/migration/V1__create_tables.sql
@@ -37,22 +37,16 @@ CREATE TABLE lances (
                         advogado_id BIGINT NOT NULL,
                         causa_id BIGINT NOT NULL,
                         valor DECIMAL(10,2) NOT NULL,
+                        status ENUM('PENDENTE', 'ACEITO', 'NEGOCIANDO') NOT NULL,
                         FOREIGN KEY (advogado_id) REFERENCES advogados(id) ON DELETE CASCADE,
                         FOREIGN KEY (causa_id) REFERENCES causas(id) ON DELETE CASCADE
 );
 
-CREATE TABLE chat (
-                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
-                        lance_id BIGINT NOT NULL,
-                        proposta_aceita BOOLEAN NOT NULL DEFAULT FALSE,
-                        FOREIGN KEY (lance_id) REFERENCES lances(id) ON DELETE CASCADE
-);
-
 CREATE TABLE mensagens (
                            id BIGINT AUTO_INCREMENT PRIMARY KEY,
-                           chat_id BIGINT NOT NULL,
-                           conteudo TEXT NOT NULL,
-                           enviada_em TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                           lance_id BIGINT NOT NULL,
                            remetente ENUM('USUARIO', 'ADVOGADO') NOT NULL,
-                           FOREIGN KEY (chat_id) REFERENCES chat(id) ON DELETE CASCADE
+                           mensagem TEXT NOT NULL,
+                           data_envio TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                           FOREIGN KEY (lance_id) REFERENCES lances(id) ON DELETE CASCADE
 );

--- a/api-advogados-backup-master/src/main/resources/db/migration/V2__add_chat_and_update_lances.sql
+++ b/api-advogados-backup-master/src/main/resources/db/migration/V2__add_chat_and_update_lances.sql
@@ -1,0 +1,21 @@
+-- Add chat table and update lances/messages relations
+ALTER TABLE lances
+    DROP COLUMN status;
+
+CREATE TABLE chat (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    lance_id BIGINT NOT NULL,
+    proposta_aceita BOOLEAN NOT NULL DEFAULT FALSE,
+    FOREIGN KEY (lance_id) REFERENCES lances(id) ON DELETE CASCADE
+);
+
+DROP TABLE mensagens;
+
+CREATE TABLE mensagens (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    chat_id BIGINT NOT NULL,
+    conteudo TEXT NOT NULL,
+    enviada_em TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    remetente ENUM('USUARIO', 'ADVOGADO') NOT NULL,
+    FOREIGN KEY (chat_id) REFERENCES chat(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## Summary
- Restore original V1 migration to match existing Flyway checksum
- Introduce V2 migration to drop `lances.status`, add `chat` table, and rebuild `mensagens`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; Maven Central unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cade485ec8329ac9d5392e4119903