### PR TITLE
feat: approve bids and track history

### DIFF
--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/DTOs/Lance/LancePendenteResponseDTO.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/DTOs/Lance/LancePendenteResponseDTO.java
@@ -1,0 +1,8 @@
+package advogados_popular.api_advogados_popular.DTOs.Lance;
+
+import java.math.BigDecimal;
+
+public record LancePendenteResponseDTO(Long id, BigDecimal valor,
+                                       Long causaId, String causaTitulo,
+                                       Long advogadoId, String advogadoNome) {
+}

--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/Repositorys/CausaRepository.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/Repositorys/CausaRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 
 public interface CausaRepository extends JpaRepository<Causa, Long> {
     List<Causa> findByStatusNot(statusCausa status);
+
+    List<Causa> findByLances_Advogado_IdAndLances_Chat_PropostaAceitaTrue(Long advogadoId);
 }

--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/Repositorys/LanceRepository.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/Repositorys/LanceRepository.java
@@ -3,6 +3,9 @@ package advogados_popular.api_advogados_popular.Repositorys;
 import advogados_popular.api_advogados_popular.Entitys.Lance;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface LanceRepository extends JpaRepository<Lance, Long> {
+    List<Lance> findByCausa_Usuario_IdAndChat_PropostaAceitaFalse(Long usuarioId);
 }
 

--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/controllers/LanceController.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/controllers/LanceController.java
@@ -2,6 +2,7 @@ package advogados_popular.api_advogados_popular.controllers;
 
 import advogados_popular.api_advogados_popular.DTOs.Lance.LanceRequestDTO;
 import advogados_popular.api_advogados_popular.DTOs.Lance.LanceResponseDTO;
+import advogados_popular.api_advogados_popular.DTOs.Lance.LancePendenteResponseDTO;
 import advogados_popular.api_advogados_popular.sevices.LanceService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,16 @@ public class LanceController {
     @PostMapping
     public ResponseEntity<LanceResponseDTO> criar(@RequestBody LanceRequestDTO dto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(lanceService.criarLance(dto));
+    }
+
+    @GetMapping("/pendentes")
+    public ResponseEntity<java.util.List<LancePendenteResponseDTO>> listarPendentes() {
+        return ResponseEntity.ok(lanceService.listarPendentesUsuario());
+    }
+
+    @PostMapping("/{id}/aprovar")
+    public ResponseEntity<LanceResponseDTO> aprovar(@PathVariable Long id) {
+        return ResponseEntity.ok(lanceService.aprovarLance(id));
     }
 }
 

--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/sevices/CausaService.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/sevices/CausaService.java
@@ -5,9 +5,11 @@ import advogados_popular.api_advogados_popular.DTOs.Causa.CausaResponseDTO;
 import advogados_popular.api_advogados_popular.DTOs.statusCausa;
 import advogados_popular.api_advogados_popular.DTOs.utils.Role;
 import advogados_popular.api_advogados_popular.Entitys.Account;
+import advogados_popular.api_advogados_popular.Entitys.Advogado;
 import advogados_popular.api_advogados_popular.Entitys.Causa;
 import advogados_popular.api_advogados_popular.Entitys.User;
 import advogados_popular.api_advogados_popular.Repositorys.AccountRepository;
+import advogados_popular.api_advogados_popular.Repositorys.AdvogadoRepository;
 import advogados_popular.api_advogados_popular.Repositorys.CausaRepository;
 import advogados_popular.api_advogados_popular.Repositorys.UserRepository;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -22,13 +24,16 @@ public class CausaService {
     private final CausaRepository causaRepository;
     private final UserRepository usuarioRepository;
     private final AccountRepository accountRepository;
+    private final AdvogadoRepository advogadoRepository;
 
     public CausaService(CausaRepository causaRepository,
                         UserRepository usuarioRepository,
-                        AccountRepository accountRepository) {
+                        AccountRepository accountRepository,
+                        AdvogadoRepository advogadoRepository) {
         this.causaRepository = causaRepository;
         this.usuarioRepository = usuarioRepository;
         this.accountRepository = accountRepository;
+        this.advogadoRepository = advogadoRepository;
     }
 
     public List<CausaResponseDTO> listarCausas() {
@@ -62,7 +67,10 @@ public class CausaService {
             throw new RuntimeException("Apenas advogados podem visualizar as causas.");
         }
 
-        return causaRepository.findByStatusNot(statusCausa.ABERTA).stream()
+        Advogado advogado = advogadoRepository.findByAccount(account)
+                .orElseThrow(() -> new RuntimeException("Advogado não encontrado"));
+
+        return causaRepository.findByLances_Advogado_IdAndLances_Chat_PropostaAceitaTrue(advogado.getId()).stream()
                 .map(causa -> new CausaResponseDTO(
                         causa.getId(),
                         causa.getTitulo(),

--- a/front-advogados-backup-master/src/app/dashboard/page.tsx
+++ b/front-advogados-backup-master/src/app/dashboard/page.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { FileText, Briefcase, User, AlertTriangle, Loader2, ExternalLink } from 'lucide-react';
 import Image from 'next/image';
 import CaseList from '@/components/CaseList'; // Import CaseList
+import PendingBidsList from '@/components/PendingBidsList';
 
 export default function DashboardPage() {
   const { user, isLoading, isAuthenticated } = useAuthRedirect({ requiredAuth: true });
@@ -51,6 +52,7 @@ export default function DashboardPage() {
       </Card>
 
       {user.role === 'USUARIO' && (
+        <>
         <div className="grid md:grid-cols-2 gap-6 lg:gap-8">
           <Card className="bg-card rounded-xl shadow-card-modern hover:shadow-card-modern-hover transition-all duration-300 ease-in-out transform hover:-translate-y-1">
             <CardHeader className="p-6">
@@ -89,8 +91,12 @@ export default function DashboardPage() {
                 Acreditamos no poder da colaboração para promover o acesso à justiça. Advogados Solidários é uma plataforma que une pessoas que precisam de orientação legal com advogados dispostos a oferecer seu tempo e conhecimento de forma voluntária. Juntos, construímos uma sociedade mais justa e igualitária.
               </p>
             </CardContent>
-          </Card>
+        </Card>
         </div>
+        <div className="mt-8">
+          <PendingBidsList />
+        </div>
+        </>
       )}
 
       {user.role === 'ADVOGADO' && (

--- a/front-advogados-backup-master/src/components/ChatModal.tsx
+++ b/front-advogados-backup-master/src/components/ChatModal.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { API_BASE_URL } from '@/config/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { useToast } from '@/hooks/use-toast';
+
+interface ChatModalProps {
+  chatId: number;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface Message {
+  id: number;
+  conteudo: string;
+  remetente: string;
+}
+
+export default function ChatModal({ chatId, open, onOpenChange }: ChatModalProps) {
+  const { token, user } = useAuth();
+  const { toast } = useToast();
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [newMessage, setNewMessage] = useState('');
+
+  useEffect(() => {
+    const fetchMessages = async () => {
+      if (!token || !chatId || !open) return;
+      try {
+        const res = await fetch(`${API_BASE_URL}/chats/${chatId}/mensagens`, {
+          headers: { 'Authorization': `Bearer ${token}` },
+        });
+        if (!res.ok) throw new Error('Falha ao carregar mensagens');
+        const data: Message[] = await res.json();
+        setMessages(data);
+      } catch (err: any) {
+        toast({ variant: 'destructive', title: 'Erro', description: err.message });
+      }
+    };
+    fetchMessages();
+  }, [chatId, open, token, toast]);
+
+  const handleSend = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!token || !newMessage.trim()) return;
+    try {
+      const res = await fetch(`${API_BASE_URL}/chats/${chatId}/mensagens`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
+        body: JSON.stringify({ conteudo: newMessage }),
+      });
+      if (!res.ok) throw new Error('Falha ao enviar mensagem');
+      const data: Message = await res.json();
+      setMessages(prev => [...prev, data]);
+      setNewMessage('');
+    } catch (err: any) {
+      toast({ variant: 'destructive', title: 'Erro', description: err.message });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Chat</DialogTitle>
+        </DialogHeader>
+        <div className="mb-4 max-h-64 overflow-y-auto space-y-2 text-sm">
+          {messages.map(msg => (
+            <div key={msg.id} className={msg.remetente === (user?.role === 'ADVOGADO' ? 'ADVOGADO' : 'USUARIO') ? 'text-right' : 'text-left'}>
+              <span className="font-medium">
+                {msg.remetente === 'ADVOGADO' ? 'Advogado' : 'Você'}:
+              </span> {msg.conteudo}
+            </div>
+          ))}
+        </div>
+        <form onSubmit={handleSend} className="flex space-x-2">
+          <Input value={newMessage} onChange={(e) => setNewMessage(e.target.value)} className="flex-1" placeholder="Mensagem" />
+          <Button type="submit">Enviar</Button>
+        </form>
+        <DialogFooter />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front-advogados-backup-master/src/components/PendingBidsList.tsx
+++ b/front-advogados-backup-master/src/components/PendingBidsList.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { API_BASE_URL } from '@/config/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { useToast } from '@/hooks/use-toast';
+import ChatModal from './ChatModal';
+
+interface PendingBid {
+  id: number;
+  valor: number;
+  causaId: number;
+  causaTitulo: string;
+  advogadoId: number;
+  advogadoNome: string;
+}
+
+interface LanceResponse {
+  id: number;
+  valor: number;
+  causaId: number;
+  advogadoId: number;
+  chatId: number;
+}
+
+export default function PendingBidsList() {
+  const { token } = useAuth();
+  const { toast } = useToast();
+  const [bids, setBids] = useState<PendingBid[]>([]);
+  const [chatOpen, setChatOpen] = useState(false);
+  const [chatId, setChatId] = useState<number | null>(null);
+
+  useEffect(() => {
+    const fetchBids = async () => {
+      if (!token) return;
+      try {
+        const res = await fetch(`${API_BASE_URL}/lances/pendentes`, {
+          headers: { 'Authorization': `Bearer ${token}` },
+        });
+        if (!res.ok) throw new Error('Erro ao carregar lances pendentes');
+        const data: PendingBid[] = await res.json();
+        setBids(data);
+      } catch (err: any) {
+        toast({ variant: 'destructive', title: 'Erro', description: err.message });
+      }
+    };
+    fetchBids();
+  }, [token, toast]);
+
+  const handleApprove = async (id: number) => {
+    if (!token) return;
+    try {
+      const res = await fetch(`${API_BASE_URL}/lances/${id}/aprovar`, {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.message || 'Falha ao aprovar o lance');
+      }
+      const data: LanceResponse = await res.json();
+      setBids(prev => prev.filter(b => b.id !== id));
+      setChatId(data.chatId);
+      setChatOpen(true);
+      toast({ title: 'Lance aprovado', description: 'Chat iniciado com o advogado.' });
+    } catch (err: any) {
+      toast({ variant: 'destructive', title: 'Erro', description: err.message });
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {bids.length > 0 && (
+        <h2 className="text-xl font-headline text-primary">Propostas Recebidas</h2>
+      )}
+      {bids.map(bid => (
+        <Card key={bid.id} className="bg-card shadow-card-modern rounded-xl">
+          <CardHeader>
+            <CardTitle className="text-lg">{bid.causaTitulo}</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm space-y-1">
+            <p><strong>Advogado:</strong> {bid.advogadoNome}</p>
+            <p><strong>Valor:</strong> R$ {bid.valor.toFixed(2)}</p>
+          </CardContent>
+          <CardFooter>
+            <Button onClick={() => handleApprove(bid.id)}>Aprovar</Button>
+          </CardFooter>
+        </Card>
+      ))}
+      <ChatModal chatId={chatId ?? 0} open={chatOpen} onOpenChange={setChatOpen} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add endpoints so users can list and approve lances, updating cause status and opening chat
- show pending proposals with chat modal in dashboard
- record only approved lances in lawyer history

## Testing
- `npm run lint` *(fails: Next.js eslint requires initial configuration)*
- `npm run typecheck` *(fails: Property 'pathname' does not exist on type 'AppRouterInstance'; tailwind config type error)*
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_689d00b8eae883299d62a5d950fabcd2