### PR TITLE
Add chat and proposal status workflow

### DIFF
--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/DTOs/Lance/LanceRecebidaResponseDTO.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/DTOs/Lance/LanceRecebidaResponseDTO.java
@@ -1,0 +1,14 @@
+package advogados_popular.api_advogados_popular.DTOs.Lance;
+
+import advogados_popular.api_advogados_popular.DTOs.statusProposta;
+import java.math.BigDecimal;
+
+public record LanceRecebidaResponseDTO(Long id,
+                                      BigDecimal valor,
+                                      Long causaId,
+                                      String causaTitulo,
+                                      Long advogadoId,
+                                      String advogadoNome,
+                                      statusProposta status,
+                                      Long chatId) {
+}

--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/DTOs/Lance/LanceResponseDTO.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/DTOs/Lance/LanceResponseDTO.java
@@ -1,7 +1,8 @@
 package advogados_popular.api_advogados_popular.DTOs.Lance;
 
 import java.math.BigDecimal;
+import advogados_popular.api_advogados_popular.DTOs.statusProposta;
 
-public record LanceResponseDTO(Long id, BigDecimal valor, Long causaId, Long advogadoId, Long chatId) {
+public record LanceResponseDTO(Long id, BigDecimal valor, Long causaId, Long advogadoId, Long chatId, statusProposta status) {
 }
 

--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/DTOs/statusProposta.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/DTOs/statusProposta.java
@@ -1,0 +1,7 @@
+package advogados_popular.api_advogados_popular.DTOs;
+
+public enum statusProposta {
+    PENDENTE,
+    APROVADA,
+    RECUSADA
+}

--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/Entitys/Chat.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/Entitys/Chat.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import advogados_popular.api_advogados_popular.DTOs.statusProposta;
 
 // Chat.java
 @Entity
@@ -27,5 +28,6 @@ public class Chat {
     @OneToMany(mappedBy = "chat", cascade = CascadeType.ALL)
     private List<Mensagem> mensagens;
 
-    private boolean propostaAceita;
+    @Enumerated(EnumType.STRING)
+    private statusProposta status;
 }

--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/Repositorys/LanceRepository.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/Repositorys/LanceRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface LanceRepository extends JpaRepository<Lance, Long> {
-    List<Lance> findByCausa_Usuario_IdAndChat_PropostaAceitaFalse(Long usuarioId);
+    List<Lance> findByCausa_Usuario_Id(Long usuarioId);
+    List<Lance> findByAdvogado_Id(Long advogadoId);
 }
 

--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/controllers/LanceController.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/controllers/LanceController.java
@@ -2,7 +2,7 @@ package advogados_popular.api_advogados_popular.controllers;
 
 import advogados_popular.api_advogados_popular.DTOs.Lance.LanceRequestDTO;
 import advogados_popular.api_advogados_popular.DTOs.Lance.LanceResponseDTO;
-import advogados_popular.api_advogados_popular.DTOs.Lance.LancePendenteResponseDTO;
+import advogados_popular.api_advogados_popular.DTOs.Lance.LanceRecebidaResponseDTO;
 import advogados_popular.api_advogados_popular.sevices.LanceService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,14 +23,24 @@ public class LanceController {
         return ResponseEntity.status(HttpStatus.CREATED).body(lanceService.criarLance(dto));
     }
 
-    @GetMapping("/pendentes")
-    public ResponseEntity<java.util.List<LancePendenteResponseDTO>> listarPendentes() {
-        return ResponseEntity.ok(lanceService.listarPendentesUsuario());
+    @GetMapping("/recebidas")
+    public ResponseEntity<java.util.List<LanceRecebidaResponseDTO>> listarRecebidas() {
+        return ResponseEntity.ok(lanceService.listarRecebidasUsuario());
     }
 
     @PostMapping("/{id}/aprovar")
     public ResponseEntity<LanceResponseDTO> aprovar(@PathVariable Long id) {
         return ResponseEntity.ok(lanceService.aprovarLance(id));
+    }
+
+    @PostMapping("/{id}/recusar")
+    public ResponseEntity<LanceResponseDTO> recusar(@PathVariable Long id) {
+        return ResponseEntity.ok(lanceService.recusarLance(id));
+    }
+
+    @GetMapping("/historico")
+    public ResponseEntity<java.util.List<LanceRecebidaResponseDTO>> historicoAdvogado() {
+        return ResponseEntity.ok(lanceService.listarDoAdvogado());
     }
 }
 

--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/sevices/ChatService.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/sevices/ChatService.java
@@ -6,6 +6,7 @@ import advogados_popular.api_advogados_popular.DTOs.utils.Role;
 import advogados_popular.api_advogados_popular.Entitys.Account;
 import advogados_popular.api_advogados_popular.Entitys.Chat;
 import advogados_popular.api_advogados_popular.Entitys.Mensagem;
+import advogados_popular.api_advogados_popular.DTOs.statusProposta;
 import advogados_popular.api_advogados_popular.Repositorys.AccountRepository;
 import advogados_popular.api_advogados_popular.Repositorys.ChatRepository;
 import advogados_popular.api_advogados_popular.Repositorys.MensagemRepository;
@@ -43,6 +44,10 @@ public class ChatService {
         Chat chat = chatRepository.findById(chatId)
                 .orElseThrow(() -> new RuntimeException("Chat não encontrado"));
 
+        if (chat.getStatus() != statusProposta.APROVADA) {
+            throw new RuntimeException("Chat não disponível");
+        }
+
         Mensagem mensagem = new Mensagem();
         mensagem.setChat(chat);
         mensagem.setConteudo(dto.conteudo());
@@ -64,6 +69,13 @@ public class ChatService {
     }
 
     public List<MensagemResponseDTO> listarMensagens(Long chatId) {
+        Chat chat = chatRepository.findById(chatId)
+                .orElseThrow(() -> new RuntimeException("Chat não encontrado"));
+
+        if (chat.getStatus() != statusProposta.APROVADA) {
+            throw new RuntimeException("Chat não disponível");
+        }
+
         return mensagemRepository.findByChatId(chatId).stream()
                 .map(m -> new MensagemResponseDTO(
                         m.getId(),

--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/sevices/LanceService.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/sevices/LanceService.java
@@ -2,9 +2,10 @@ package advogados_popular.api_advogados_popular.sevices;
 
 import advogados_popular.api_advogados_popular.DTOs.Lance.LanceRequestDTO;
 import advogados_popular.api_advogados_popular.DTOs.Lance.LanceResponseDTO;
-import advogados_popular.api_advogados_popular.DTOs.Lance.LancePendenteResponseDTO;
+import advogados_popular.api_advogados_popular.DTOs.Lance.LanceRecebidaResponseDTO;
 import advogados_popular.api_advogados_popular.DTOs.utils.Role;
 import advogados_popular.api_advogados_popular.DTOs.statusCausa;
+import advogados_popular.api_advogados_popular.DTOs.statusProposta;
 import advogados_popular.api_advogados_popular.Entitys.*;
 import advogados_popular.api_advogados_popular.Repositorys.*;
 import org.springframework.http.HttpStatus;
@@ -59,7 +60,7 @@ public class LanceService {
 
         Chat chat = new Chat();
         chat.setLance(lance);
-        chat.setPropostaAceita(false);
+        chat.setStatus(statusProposta.PENDENTE);
         if (dto.comentario() != null && !dto.comentario().isBlank()) {
             Mensagem mensagem = new Mensagem();
             mensagem.setChat(chat);
@@ -77,11 +78,12 @@ public class LanceService {
                 salvo.getValor(),
                 salvo.getCausa().getId(),
                 salvo.getAdvogado().getId(),
-                salvo.getChat().getId()
+                salvo.getChat().getId(),
+                salvo.getChat().getStatus()
         );
     }
 
-    public List<LancePendenteResponseDTO> listarPendentesUsuario() {
+    public List<LanceRecebidaResponseDTO> listarRecebidasUsuario() {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
 
         Account account = accountRepository.findByEmail(email)
@@ -94,14 +96,16 @@ public class LanceService {
         User usuario = userRepository.findByAccount(account)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Usuário não encontrado"));
 
-        return lanceRepository.findByCausa_Usuario_IdAndChat_PropostaAceitaFalse(usuario.getId()).stream()
-                .map(l -> new LancePendenteResponseDTO(
+        return lanceRepository.findByCausa_Usuario_Id(usuario.getId()).stream()
+                .map(l -> new LanceRecebidaResponseDTO(
                         l.getId(),
                         l.getValor(),
                         l.getCausa().getId(),
                         l.getCausa().getTitulo(),
                         l.getAdvogado().getId(),
-                        l.getAdvogado().getNome()))
+                        l.getAdvogado().getNome(),
+                        l.getChat().getStatus(),
+                        l.getChat().getId()))
                 .toList();
     }
 
@@ -126,7 +130,7 @@ public class LanceService {
         }
 
         Chat chat = lance.getChat();
-        chat.setPropostaAceita(true);
+        chat.setStatus(statusProposta.APROVADA);
 
         Causa causa = lance.getCausa();
         causa.setStatus(statusCausa.NEGOCIANDO);
@@ -139,8 +143,70 @@ public class LanceService {
                 salvo.getValor(),
                 salvo.getCausa().getId(),
                 salvo.getAdvogado().getId(),
-                salvo.getChat().getId()
+                salvo.getChat().getId(),
+                salvo.getChat().getStatus()
         );
+    }
+
+    public LanceResponseDTO recusarLance(Long lanceId) {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        Account account = accountRepository.findByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Conta não encontrada"));
+
+        if (account.getRole() != Role.USUARIO) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Apenas usuários podem recusar lances.");
+        }
+
+        User usuario = userRepository.findByAccount(account)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Usuário não encontrado"));
+
+        Lance lance = lanceRepository.findById(lanceId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Lance não encontrado"));
+
+        if (!lance.getCausa().getUsuario().getId().equals(usuario.getId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Lance não pertence a um caso do usuário.");
+        }
+
+        Chat chat = lance.getChat();
+        chat.setStatus(statusProposta.RECUSADA);
+
+        Lance salvo = lanceRepository.save(lance);
+
+        return new LanceResponseDTO(
+                salvo.getId(),
+                salvo.getValor(),
+                salvo.getCausa().getId(),
+                salvo.getAdvogado().getId(),
+                salvo.getChat().getId(),
+                salvo.getChat().getStatus()
+        );
+    }
+
+    public List<LanceRecebidaResponseDTO> listarDoAdvogado() {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        Account account = accountRepository.findByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Conta não encontrada"));
+
+        if (account.getRole() != Role.ADVOGADO) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Apenas advogados podem visualizar histórico de lances.");
+        }
+
+        Advogado advogado = advogadoRepository.findByAccount(account)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Advogado não encontrado"));
+
+        return lanceRepository.findByAdvogado_Id(advogado.getId()).stream()
+                .map(l -> new LanceRecebidaResponseDTO(
+                        l.getId(),
+                        l.getValor(),
+                        l.getCausa().getId(),
+                        l.getCausa().getTitulo(),
+                        l.getAdvogado().getId(),
+                        l.getAdvogado().getNome(),
+                        l.getChat().getStatus(),
+                        l.getChat().getId()))
+                .toList();
     }
 }
 

--- a/front-advogados-backup-master/src/app/historico/page.tsx
+++ b/front-advogados-backup-master/src/app/historico/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import CaseList from '@/components/CaseList';
+import BidHistoryList from '@/components/BidHistoryList';
 import { useAuthRedirect } from '@/hooks/useAuthRedirect';
 import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Clock, AlertTriangle, Loader2 } from 'lucide-react';
@@ -49,6 +50,9 @@ export default function HistoricoPage() {
         </CardHeader>
       </Card>
       <CaseList apiEndpoint="/causas/historico" />
+      <div className="mt-8">
+        <BidHistoryList />
+      </div>
     </div>
   );
 }

--- a/front-advogados-backup-master/src/components/BidHistoryList.tsx
+++ b/front-advogados-backup-master/src/components/BidHistoryList.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { API_BASE_URL } from '@/config/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { useToast } from '@/hooks/use-toast';
+import ChatModal from './ChatModal';
+
+interface Bid {
+  id: number;
+  valor: number;
+  causaId: number;
+  causaTitulo: string;
+  advogadoId: number;
+  advogadoNome: string;
+  status: string;
+  chatId: number;
+}
+
+export default function BidHistoryList() {
+  const { token } = useAuth();
+  const { toast } = useToast();
+  const [bids, setBids] = useState<Bid[]>([]);
+  const [chatOpen, setChatOpen] = useState(false);
+  const [chatId, setChatId] = useState<number | null>(null);
+
+  useEffect(() => {
+    const fetchBids = async () => {
+      if (!token) return;
+      try {
+        const res = await fetch(`${API_BASE_URL}/lances/historico`, {
+          headers: { 'Authorization': `Bearer ${token}` },
+        });
+        if (!res.ok) throw new Error('Erro ao carregar histórico de propostas');
+        const data: Bid[] = await res.json();
+        setBids(data);
+      } catch (err: any) {
+        toast({ variant: 'destructive', title: 'Erro', description: err.message });
+      }
+    };
+    fetchBids();
+  }, [token, toast]);
+
+  return (
+    <div className="space-y-6">
+      {bids.length > 0 && (
+        <h2 className="text-xl font-headline text-primary">Histórico de Propostas</h2>
+      )}
+      {bids.map(bid => (
+        <Card key={bid.id} className="bg-card shadow-card-modern rounded-xl">
+          <CardHeader>
+            <CardTitle className="text-lg">{bid.causaTitulo}</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm space-y-1">
+            <p><strong>Status:</strong> {bid.status}</p>
+            <p><strong>Valor:</strong> R$ {bid.valor.toFixed(2)}</p>
+          </CardContent>
+          <CardFooter>
+            {bid.status === 'APROVADA' && (
+              <Button onClick={() => { setChatId(bid.chatId); setChatOpen(true); }}>Chat</Button>
+            )}
+          </CardFooter>
+        </Card>
+      ))}
+      <ChatModal chatId={chatId ?? 0} open={chatOpen} onOpenChange={setChatOpen} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Track proposal lifecycle with new `statusProposta` enum and chat status
- Allow users to approve or reject proposals and access chat when approved
- List proposal history for lawyers with chat access

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8388f7ce08329a724f5c67c8a8831