### PR TITLE
Fix query for accepted proposals in CausaRepository

### DIFF
--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/Repositorys/CausaRepository.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/Repositorys/CausaRepository.java
@@ -1,6 +1,7 @@
 package advogados_popular.api_advogados_popular.Repositorys;
 
 import advogados_popular.api_advogados_popular.DTOs.statusCausa;
+import advogados_popular.api_advogados_popular.DTOs.statusProposta;
 import advogados_popular.api_advogados_popular.Entitys.Causa;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,5 +10,5 @@ import java.util.List;
 public interface CausaRepository extends JpaRepository<Causa, Long> {
     List<Causa> findByStatusNot(statusCausa status);
 
-    List<Causa> findByLances_Advogado_IdAndLances_Chat_PropostaAceitaTrue(Long advogadoId);
+    List<Causa> findByLances_Advogado_IdAndLances_Chat_Status(Long advogadoId, statusProposta status);
 }

--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/sevices/CausaService.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/sevices/CausaService.java
@@ -3,6 +3,7 @@ package advogados_popular.api_advogados_popular.sevices;
 import advogados_popular.api_advogados_popular.DTOs.Causa.CausaRequestDTO;
 import advogados_popular.api_advogados_popular.DTOs.Causa.CausaResponseDTO;
 import advogados_popular.api_advogados_popular.DTOs.statusCausa;
+import advogados_popular.api_advogados_popular.DTOs.statusProposta;
 import advogados_popular.api_advogados_popular.DTOs.utils.Role;
 import advogados_popular.api_advogados_popular.Entitys.Account;
 import advogados_popular.api_advogados_popular.Entitys.Advogado;
@@ -70,7 +71,7 @@ public class CausaService {
         Advogado advogado = advogadoRepository.findByAccount(account)
                 .orElseThrow(() -> new RuntimeException("Advogado não encontrado"));
 
-        return causaRepository.findByLances_Advogado_IdAndLances_Chat_PropostaAceitaTrue(advogado.getId()).stream()
+        return causaRepository.findByLances_Advogado_IdAndLances_Chat_Status(advogado.getId(), statusProposta.APROVADA).stream()
                 .map(causa -> new CausaResponseDTO(
                         causa.getId(),
                         causa.getTitulo(),


### PR DESCRIPTION
## Summary
- update repository method to reference Chat status instead of non-existent field
- adjust service to fetch causes with approved proposals

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b84159a4d883299517b7048cbd49a6