### PR TITLE
Hide bid cases from dashboard and disable bidding in history

### DIFF
--- a/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/sevices/CausaService.java
+++ b/api-advogados-backup-master/src/main/java/advogados_popular/api_advogados_popular/sevices/CausaService.java
@@ -47,7 +47,13 @@ public class CausaService {
             throw new RuntimeException("Apenas advogados podem visualizar as causas.");
         }
 
+        Advogado advogado = advogadoRepository.findByAccount(account)
+                .orElseThrow(() -> new RuntimeException("Advogado não encontrado"));
+
         return causaRepository.findAll().stream()
+                // Exibe apenas causas em que o advogado ainda não deu lance
+                .filter(causa -> causa.getLances().stream()
+                        .noneMatch(l -> l.getAdvogado().getId().equals(advogado.getId())))
                 .map(causa -> new CausaResponseDTO(
                         causa.getId(),
                         causa.getTitulo(),
@@ -71,7 +77,10 @@ public class CausaService {
         Advogado advogado = advogadoRepository.findByAccount(account)
                 .orElseThrow(() -> new RuntimeException("Advogado não encontrado"));
 
-        return causaRepository.findByLances_Advogado_IdAndLances_Chat_Status(advogado.getId(), statusProposta.APROVADA).stream()
+        return causaRepository.findAll().stream()
+                // Inclui apenas causas com lances do advogado
+                .filter(causa -> causa.getLances().stream()
+                        .anyMatch(l -> l.getAdvogado().getId().equals(advogado.getId())))
                 .map(causa -> new CausaResponseDTO(
                         causa.getId(),
                         causa.getTitulo(),

--- a/front-advogados-backup-master/src/app/historico/page.tsx
+++ b/front-advogados-backup-master/src/app/historico/page.tsx
@@ -49,7 +49,7 @@ export default function HistoricoPage() {
           </div>
         </CardHeader>
       </Card>
-      <CaseList apiEndpoint="/causas/historico" />
+      <CaseList apiEndpoint="/causas/historico" showBidButton={false} />
       <div className="mt-8">
         <BidHistoryList />
       </div>

--- a/front-advogados-backup-master/src/components/BidModal.tsx
+++ b/front-advogados-backup-master/src/components/BidModal.tsx
@@ -13,9 +13,10 @@ interface BidModalProps {
   caseId: number;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onBidSubmitted?: () => void;
 }
 
-export default function BidModal({ caseId, open, onOpenChange }: BidModalProps) {
+export default function BidModal({ caseId, open, onOpenChange, onBidSubmitted }: BidModalProps) {
   const { token } = useAuth();
   const { toast } = useToast();
   const [comment, setComment] = useState('');
@@ -57,6 +58,7 @@ export default function BidModal({ caseId, open, onOpenChange }: BidModalProps) 
       setComment('');
       setValue('');
       onOpenChange(false);
+      onBidSubmitted?.();
     } catch (err: any) {
       toast({ variant: 'destructive', title: 'Erro', description: err.message });
     }

--- a/front-advogados-backup-master/src/components/CaseCard.tsx
+++ b/front-advogados-backup-master/src/components/CaseCard.tsx
@@ -19,9 +19,11 @@ export interface Case {
 interface CaseCardProps {
   caseData: Case;
   onViewDetails?: (caseId: number) => void;
+  onBidSubmitted?: (caseId: number) => void;
+  showBidButton?: boolean;
 }
 
-const CaseCard: React.FC<CaseCardProps> = ({ caseData, onViewDetails }) => {
+const CaseCard: React.FC<CaseCardProps> = ({ caseData, onViewDetails, onBidSubmitted, showBidButton = true }) => {
   const [bidOpen, setBidOpen] = useState(false);
   const formatDate = (dateString?: string) => {
     if (!dateString) return 'Data não informada';
@@ -75,18 +77,25 @@ const CaseCard: React.FC<CaseCardProps> = ({ caseData, onViewDetails }) => {
             >
               Ver Detalhes <ArrowRight className="ml-2 h-4 w-4 opacity-70 group-hover:opacity-100 group-hover:translate-x-1 transition-transform"/>
             </Button>
-            <Button
-              variant="secondary"
-              className="w-full"
-              onClick={() => setBidOpen(true)}
-            >
-              Dar Lance
-            </Button>
+            {showBidButton && (
+              <Button
+                variant="secondary"
+                className="w-full"
+                onClick={() => setBidOpen(true)}
+              >
+                Dar Lance
+              </Button>
+            )}
           </div>
         ) : (
            <p className="text-xs text-muted-foreground italic w-full text-center">Mais ações em breve</p>
         )}
-        <BidModal caseId={caseData.id} open={bidOpen} onOpenChange={setBidOpen} />
+        <BidModal
+          caseId={caseData.id}
+          open={bidOpen}
+          onOpenChange={setBidOpen}
+          onBidSubmitted={() => onBidSubmitted?.(caseData.id)}
+        />
       </CardFooter>
     </Card>
   );

--- a/front-advogados-backup-master/src/components/CaseList.tsx
+++ b/front-advogados-backup-master/src/components/CaseList.tsx
@@ -15,6 +15,7 @@ import { useRouter } from 'next/navigation';
 
 interface CaseListProps {
   apiEndpoint?: string;
+  showBidButton?: boolean;
 }
 
 // Interface for the raw data structure from the API
@@ -32,7 +33,7 @@ interface ApiCase {
 }
 
 
-const CaseList: React.FC<CaseListProps> = ({ apiEndpoint = '/causas' }) => {
+const CaseList: React.FC<CaseListProps> = ({ apiEndpoint = '/causas', showBidButton = true }) => {
   const [cases, setCases] = useState<Case[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -93,6 +94,10 @@ const CaseList: React.FC<CaseListProps> = ({ apiEndpoint = '/causas' }) => {
   const router = useRouter();
   const handleViewDetails = (caseId: number) => {
     router.push(`/cases/${caseId}`);
+  };
+
+  const handleBidSubmitted = (caseId: number) => {
+    setCases(prev => prev.filter(c => c.id !== caseId));
   };
 
   const filteredCases = cases.filter(caseItem =>
@@ -157,7 +162,13 @@ const CaseList: React.FC<CaseListProps> = ({ apiEndpoint = '/causas' }) => {
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 xl:gap-8">
           {filteredCases.map((caseItem) => (
-            <CaseCard key={caseItem.id} caseData={caseItem} onViewDetails={handleViewDetails} />
+            <CaseCard
+              key={caseItem.id}
+              caseData={caseItem}
+              onViewDetails={handleViewDetails}
+              onBidSubmitted={handleBidSubmitted}
+              showBidButton={showBidButton}
+            />
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary
- filter cases with lawyer bids out of dashboard and include them in history
- hide bid button on historical cases and remove cases from list after bidding

## Testing
- `npm test` *(fails: Missing script "test")*
- `./mvnw -q test` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b8480078b08329a7008d25d231762b