### PR TITLE
Stop automatic case creation on login

### DIFF
--- a/front-advogados-backup-master/src/components/LoginFormComponent.tsx
+++ b/front-advogados-backup-master/src/components/LoginFormComponent.tsx
@@ -82,45 +82,6 @@ export function LoginFormComponent() {
         oab: result.oab || (result.user ? result.user.oab : undefined),
       };
 
-      // If user is USUARIO, attempt to create a default case
-      if (userData.role === 'USUARIO' && result.token) {
-        try {
-          const casePayload = {
-            titulo: "Nova Causa Automática", // Default title
-            descricao: "Causa criada automaticamente após o login.", // Default description
-            status: "ABERTA"
-          };
-          const caseResponse = await fetch(`${API_BASE_URL}/causas`, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              "Authorization": `Bearer ${result.token}`, // Use the token obtained from login
-            },
-            body: JSON.stringify(casePayload),
-          });
-
-          if (!caseResponse.ok) {
-            const caseErrorResult = await caseResponse.json().catch(() => ({ message: "Erro desconhecido ao criar causa." }));
-            console.error("Erro ao criar causa automática:", caseErrorResult.message);
-            // Optionally, inform the user with a non-blocking toast:
-            // toast({
-            //   variant: "destructive",
-            //   title: "Aviso",
-            //   description: "Não foi possível iniciar uma causa padrão automaticamente.",
-            // });
-          } else {
-            console.log("Causa automática criada com sucesso.");
-            // Optionally, inform the user:
-            // toast({
-            //   title: "Causa padrão criada",
-            //   description: "Uma nova causa foi iniciada para você no painel.",
-            // });
-          }
-        } catch (caseError) {
-          console.error("Erro de rede ou inesperado ao criar causa automática:", (caseError as Error).message);
-        }
-      }
-
       login(result.token, userData); // This will handle storing token, user data, and redirecting
 
       toast({


### PR DESCRIPTION
## Summary
- prevent automatic default case creation when users log in

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*
- `npm run typecheck` *(fails: Property 'pathname' does not exist on type 'AppRouterInstance')*

------
https://chatgpt.com/codex/tasks/task_e_68b84f3f202883298bfb255e58029571